### PR TITLE
Use SVG file to display chessboard in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Terminal Chess
 
-![image](https://user-images.githubusercontent.com/82065181/226206893-6ee3e12d-89a6-47ef-9ce0-9ed6f41c2d6f.png)
+![chess2](https://user-images.githubusercontent.com/82065181/226863987-54fd282b-eaea-4213-bb62-8eaafa35a10c.svg)
+
+
 
 ## Compile and run
 ```sh


### PR DESCRIPTION
Used https://github.com/wader/ansisvg to render svg, will match terminal for a given system unless someone decides to use a sans-serif font for their terminal


New:

![chess2](https://user-images.githubusercontent.com/82065181/226863987-54fd282b-eaea-4213-bb62-8eaafa35a10c.svg)

Old:

![image](https://user-images.githubusercontent.com/82065181/226206893-6ee3e12d-89a6-47ef-9ce0-9ed6f41c2d6f.png)